### PR TITLE
Adding missing UART2 clock to device tree

### DIFF
--- a/linux-source-6.1/arch/arm/boot/dts/caninos-k5.dts
+++ b/linux-source-6.1/arch/arm/boot/dts/caninos-k5.dts
@@ -377,6 +377,8 @@
 			interrupts = <GIC_SPI 31 IRQ_TYPE_LEVEL_HIGH>;
 			resets = <&rst RST_UART2>;
 			reset-names = "uart";
+			clocks = <&cmu CLK_UART2>;
+			clock-names = "uart";
 			status = "okay";
 			
 			pinctrl-names = "default";


### PR DESCRIPTION
Adding clock configuration for UART2 to the device tree